### PR TITLE
Add logs service.

### DIFF
--- a/pytest_localstack/constants.py
+++ b/pytest_localstack/constants.py
@@ -49,6 +49,7 @@ SERVICE_PORTS = {
     "firehose": 4573,
     "kinesis": 4568,
     "lambda": 4574,
+    "logs": 4586,
     "redshift": 4577,
     "route53": 4580,
     "s3": 4572,

--- a/pytest_localstack/contrib/botocore.py
+++ b/pytest_localstack/contrib/botocore.py
@@ -5,6 +5,7 @@ import contextlib
 import functools
 import inspect
 import logging
+import socket
 import weakref
 
 import botocore
@@ -208,7 +209,10 @@ class BotocoreTestResourceFactory(object):
             @functools.wraps(_original_convert_to_request_dict)
             def _convert_to_request_dict(self, *args, **kwargs):
                 request_dict = _original_convert_to_request_dict(self, *args, **kwargs)
-                assert factory.localstack_session.hostname in request_dict["url"]
+                assert any(
+                    (factory.localstack_session.hostname in request_dict["url"],
+                    socket.gethostname() in request_dict["url"])
+                )
                 return request_dict
 
             patches.append(

--- a/pytest_localstack/service_checks.py
+++ b/pytest_localstack/service_checks.py
@@ -128,6 +128,7 @@ SERVICE_CHECKS = {
     "firehose": check_firehose,
     "kinesis": check_kinesis,
     "lambda": port_check("lambda"),
+    "logs": port_check("logs"),
     "redshift": port_check("redshift"),
     "route53": port_check("route53"),
     "s3": check_s3,


### PR DESCRIPTION
Allow services to provide docker container name rather than just localhost in request dictionary url assertion.