### PR TITLE
Exclude tests from install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def setup_package():
         author_email=about["__author_email__"],
         license="MIT",
         url=about["__uri__"],
-        packages=find_packages(where=HERE, exclude=["tests"]),
+        packages=find_packages(where=HERE, exclude=["tests*"]),
         py_modules=["pytest_localstack"],
         install_requires=REQUIRES,
         tests_require=TEST_REQUIREMENTS,


### PR DESCRIPTION
The exclude should be `tests*` rather than just `tests` to exclude all tests from install.