### PR TITLE
Cleanup boto3.DEFAULT_SESSION when patches exit

### DIFF
--- a/pytest_localstack/contrib/botocore.py
+++ b/pytest_localstack/contrib/botocore.py
@@ -8,6 +8,7 @@ import logging
 import socket
 import weakref
 
+import boto3
 import botocore
 import botocore.client
 import botocore.config
@@ -102,6 +103,7 @@ class BotocoreTestResourceFactory(object):
         #   that overrides specific properties of the Client instances.
         #   TODO: Could we use use `gc.get_referrers()` to find instances?
         logger.debug("enter patch")
+        pre_existing_session = boto3.DEFAULT_SESSION
         try:
             factory = self
             patches = []
@@ -302,6 +304,7 @@ class BotocoreTestResourceFactory(object):
                 yield
         finally:
             logger.debug("exit patch")
+            boto3.DEFAULT_SESSION = pre_existing_session
 
 
 def patch_fixture(


### PR DESCRIPTION
When our patches exit, the DEFAULT_SESSION global from boto3 is left as an invalid session in a incomplete state after having it's `_components` removed. We should reset this global to how it was prior to the patch.