### PR TITLE
Change to use single localstack port

### DIFF
--- a/pytest_localstack/constants.py
+++ b/pytest_localstack/constants.py
@@ -39,30 +39,33 @@ DEFAULT_AWS_SECRET_ACCESS_KEY = "secretkey"
 DEFAULT_AWS_SESSION_TOKEN = "token"
 
 # Mapping AWS service name to default Localstack port.
-SERVICE_PORTS = {
-    "apigateway": 4567,
-    "cloudformation": 4581,
-    "cloudwatch": 4582,
-    "dynamodb": 4569,
-    "dynamodbstreams": 4570,
-    "ec2": 4597,
-    "es": 4578,
-    "firehose": 4573,
-    "iam": 4593,
-    "kinesis": 4568,
-    "lambda": 4574,
-    "logs": 4586,
-    "redshift": 4577,
-    "route53": 4580,
-    "s3": 4572,
-    "secretsmanager": 4584,
-    "ses": 4579,
-    "sns": 4575,
-    "sqs": 4576,
-    "ssm": 4583,
-    "stepfunctions": 4585,
-    "sts": 4592,
-}
+
+SUPPORTED_SERVICES = [
+    "apigateway",
+    "cloudformation",
+    "cloudwatch",
+    "dynamodb",
+    "dynamodbstreams",
+    "ec2",
+    "es",
+    "firehose",
+    "iam",
+    "kinesis",
+    "lambda",
+    "logs",
+    "redshift",
+    "route53",
+    "s3",
+    "secretsmanager",
+    "ses",
+    "sns",
+    "sqs",
+    "ssm",
+    "stepfunctions",
+    "sts",
+]
+
+SERVICE_PORTS = {service:4566 for service in SUPPORTED_SERVICES}
 
 # AWS uses multiple names for some services. Map alias to service name.
 SERVICE_ALIASES = {


### PR DESCRIPTION
Localstack has introduced a breaking point where the latest version does not expose individual ports for the services anymore.