### PR TITLE
Update docker to 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ services:
 - docker
 language: python
 python:
-- '3.6'
 - '3.7'
 - '3.8'
 - '3.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ include = ["CHANGELOG.rst", "LICENSE"]
 localstack = "pytest_localstack"
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = "^3.7.0"
 botocore = "^1.4.31,!=1.4.45"
-docker = "^4.0.0"
+docker = "^6.0.0"
 pluggy = "^0.12.0"
 pytest = "^6.0.0"  # need caplog (+ warnings for tests)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-localstack"
-version = "0.6.0"
+version = "1.0.0"
 description = "Pytest plugin for AWS integration tests"
 authors = ["Mintel Group Ltd."]
 license = "MIT"


### PR DESCRIPTION
This was prompted by a bunch of deprecation warnings that turned out to be coming from the docker package; version 6.0.0 of it fixes them. It doesn't support python <3.7, so a version of pytest-localstack that uses it won't be able to do so either.